### PR TITLE
Fix: --cluster-nickname does not exist

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,7 +41,6 @@ alertmanager_wechat_corp_id: ''
 alertmanager_cluster: {}
 # alertmanager_cluster:
 #   listen-address: "{{ ansible_default_ipv4.address }}:6783"
-#   nickname: "{{ ansible_hostname }}"
 #   peers:
 #     - "{{ ansible_default_ipv4.address }}:6783"
 #     - "demo.cloudalchemy.org:6783"


### PR DESCRIPTION
```
/usr/local/bin/alertmanager --cluster.listen-address=a.b.c.d:6783 --cluster.peer=a.b.c.d:6783 \
--cluster.nickname=prometheus --config.file=/etc/alertmanager/alertmanager.yml \
--storage.path=/var/lib/alertmanager \
--web.listen-address=127.0.0.1:9093 \
--web.external-url=http://monitoring.local/alertmanager/
alertmanager: error: unknown long flag '--cluster.nickname', try --help
```